### PR TITLE
Use sample DB file in repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,3 +152,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Ignore DB config
+config/database.js

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ We'll need to install Gulp and a few of it's dependencies:
 1. Clone this respository: `git clone https://github.com/ufacm/ufacm.xyz.git`
 2. In the root directory, install the correct dependencies using `npm`: `npm i`
 3. In the `/app` directory, create the `users.htpasswd` file: `touch users.htpasswd`
-4. Using your mLab MongoDB connection string from above, edit `config/database.js` to use your mLab MongoDB database.
+4. Rename `config/database.js.sample` to `config/database.js` and use your mLab MongoDB connection string from above to point the web app towards your mLab database.
 5. Run the application with Gulp in the root directory: `gulp`
-6. Using mLab's online user interface, make one of your test users an admin by
+6. Using mLab's online user interface, make one of your test users an admin.
 
 ## Running the Application
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ We'll need to install Gulp and a few of it's dependencies:
 1. Clone this respository: `git clone https://github.com/ufacm/ufacm.xyz.git`
 2. In the root directory, install the correct dependencies using `npm`: `npm i`
 3. In the `/app` directory, create the `users.htpasswd` file: `touch users.htpasswd`
-4. Rename `config/database.js.sample` to `config/database.js` and use your mLab MongoDB connection string from above to point the web app towards your mLab database.
+4. Copy the `config/database.js.sample` to `config/database.js` and use your mLab MongoDB connection string from above to point the web app towards your mLab database.
 5. Run the application with Gulp in the root directory: `gulp`
 6. Using mLab's online user interface, make one of your test users an admin.
 

--- a/config/database.js
+++ b/config/database.js
@@ -1,6 +1,0 @@
-// config/database.js
-module.exports = {
-
-	'url' : 'MongoDBURIExample' // looks like mongodb://<user>:<pass>@mongo.onmodulus.net:27017/Mikha4ot
-
-};

--- a/config/database.js.sample
+++ b/config/database.js.sample
@@ -1,0 +1,5 @@
+// Rename this file to database.js and fill in the information!
+
+module.exports = {
+  'url' : 'mongodb://<user>:<pass>@<mongodb-url>:<port>/<dbname>'
+};


### PR DESCRIPTION
This PR adds a sample DB file and deletes the "real" file. This is to prevent someone from accidentally pushing the DB creds.
